### PR TITLE
Eve Scout Fix

### DIFF
--- a/app/Client/EveScout/EveScout.php
+++ b/app/Client/EveScout/EveScout.php
@@ -15,20 +15,44 @@ class EveScout extends Client\AbstractApi implements EveScoutInterface {
     /**
      * @return RequestConfig
      */
-    protected function getTheraConnectionsRequest() : RequestConfig {
+    protected function getTheraConnectionsRequest(): RequestConfig {
         return new RequestConfig(
-            WebClient::newRequest('GET', $this->getConfig()->getEndpoint(['wormholes', 'GET'])),
+            WebClient::newRequest('GET', $this->getConfig()->getEndpoint(['signatures', 'GET'])),
             [],
-            function($body) : array {
+            function($body): array {
                 $connectionsData = [];
-                if(!$body->error){
-                    foreach((array)$body as $data){
-                        $connectionsData['connections'][(int)$data->id] = (new Mapper\Connection($data))->getData();
-                    }
-                }else{
+                if(isset($body->error)){
                     $connectionsData['error'] = $body->error;
+                    return $connectionsData;
                 }
+    
+                foreach ($body as $data) {
+                    $connectionId = (int)$data->id;
+                    $wh_type = (string)$data->wh_type;
+                    $target_region_id = (int)$data->in_region_id;
+                    $target_region_name = (string)$data->in_region_name;
+                    $outbound = (bool)$data->wh_exits_outward;
+                    $remaining_hours = (int)$data->remaining_hours;
 
+                  
+                    $connectionData = (new Mapper\Connection($data))->getData();
+                    // Add connection data
+                    $connectionsData['connections'][$connectionId] = $connectionData;
+
+                    // Set End of Life status
+                    $connectionsData['connections'][$connectionId]['eol'] = $remaining_hours <= 4 ? "critical" : "fresh";
+    
+                    // Determine wormhole types
+                    $outboundSig = $outbound ? 'sourceSignature' : 'targetSignature';
+                    $connectionsData['connections'][$connectionId][$outboundSig]['type'] = $wh_type;
+
+
+                    // Need to fix iterator to handle nesting so for now pulling out the region
+                    //        'in_region_id'                      => ['target' => ['region' => 'id']],
+                    $connectionsData['connections'][$connectionId]['target']['region']['id'] = $target_region_id;
+                    //        'in_region_name'                    => ['target' => ['region' => 'name']],
+                    $connectionsData['connections'][$connectionId]['target']['region']['name'] = $target_region_name;
+                }
                 return $connectionsData;
             }
         );

--- a/app/Config/EveScout/Config.php
+++ b/app/Config/EveScout/Config.php
@@ -11,8 +11,8 @@ class Config extends AbstractConfig {
      * @var array
      */
     protected static $spec = [
-        'wormholes' => [
-            'GET' => '/api/wormholes'
+        'signatures' => [
+            'GET' => 'v2/public/signatures'
         ]
     ];
 }

--- a/app/Mapper/EveScout/Connection.php
+++ b/app/Mapper/EveScout/Connection.php
@@ -12,28 +12,28 @@ class Connection extends AbstractIterator {
      */
     protected static $map = [
         'id'                                => 'id',
-        'type'                              => 'type',
+        'signature_type'                    => 'type',
+        'in_system_name'                    => 'name',
+        'completed'                         => ['state' => 'name'],
+        'updated_at'                        => ['state' => 'updated'],
 
-        'status'                            => ['state' => 'name'],
-        'statusUpdatedAt'                   => ['state' => 'updated'],
+        //Thera || Turner
+        'out_system_id'                     => ['source' => 'id'],
+        'out_system_name'                   => ['source' => 'name'],
+        'out_signature'                     => ['sourceSignature' => 'name'],
 
-        'sourceSolarSystem'                 => 'source',
-        'destinationSolarSystem'            => 'target',
+        //Connection
+        'in_system_id'                      => ['target' => 'id'],
+        'in_system_name'                    => ['target' => 'name'],
+        'in_signature'                      => ['targetSignature' => 'name'],
 
-        'signatureId'                       => ['sourceSignature' => 'name'],
-        'sourceWormholeType'                => ['sourceSignature' => 'type'],
+        
+        'expires_at'                        => ['wormhole' => 'estimatedEol'],
 
-        'wormholeDestinationSignatureId'    => ['targetSignature' => 'name'],
-        'destinationWormholeType'           => ['targetSignature' => 'type'],
+        'created_at'                        => 'created',
+        'updated_at'                        => 'updated',
 
-        'wormholeMass'                      => ['wormhole' => 'mass'],
-        'wormholeEol'                       => ['wormhole' => 'eol'],
-        'wormholeEstimatedEol'              => ['wormhole' => 'estimatedEol'],
-
-        'createdAt'                         => 'created',
-        'updatedAt'                         => 'updated',
-
-        'createdById'                       => ['character' => 'id'],
-        'createdBy'                         => ['character' => 'name']
+        'created_by_id'                     => ['character' => 'id'],
+        'created_by_name'                   => ['character' => 'name']
     ];
 }


### PR DESCRIPTION
Eve Scout API changes were pretty drastic. In many cases, there is not an easy 1:1 swap, so additional logic needed to be added. This also forces some changes on the pathfinder side to handle some of the missing data or handling Turner as an additional system.