### PR TITLE
Update/php 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "php-64bit": ">=7.2",
     "ext-json": "*",
     "guzzlehttp/guzzle": "6.5.*",
-    "caseyamcl/guzzle_retry_middleware": "2.3.*",
+    "caseyamcl/guzzle_retry_middleware": "2.5",
     "cache/void-adapter": "1.1.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
     "ext-json": "*",
     "guzzlehttp/guzzle": "6.5.*",
     "caseyamcl/guzzle_retry_middleware": "2.3.*",
-    "cache/void-adapter": "1.0.*"
+    "cache/void-adapter": "1.1.0"
   }
 }


### PR DESCRIPTION
2 packages that are blocking a PHP 8 update.
caseyamcl/guzzle_retry_middleware
and 
cache/void-adapter

